### PR TITLE
feat(oracle-es2): assistant de rédaction interne (RAG) sur /oracle-es2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -52,6 +52,16 @@ publish = "dist"
   status = 200
 
 [[redirects]]
+  from = "/api/oracle-es2-add"
+  to = "/.netlify/functions/oracle-es2-add"
+  status = 200
+
+[[redirects]]
+  from = "/api/oracle-es2-generate"
+  to = "/.netlify/functions/oracle-es2-generate"
+  status = 200
+
+[[redirects]]
   from = "/api/mailerlite-group-count"
   to = "/.netlify/functions/mailerlite-group-count"
   status = 200

--- a/netlify/functions/lib/oracle-es2-rate-limit.mjs
+++ b/netlify/functions/lib/oracle-es2-rate-limit.mjs
@@ -1,0 +1,76 @@
+// Rate-limit anti-brute-force pour /oracle-es2 (mêmes règles que admin-es2-login).
+// Store Netlify Blobs séparé pour ne pas bloquer/débloquer en commun avec l'admin.
+// 5 échecs consécutifs par IP => blocage 15 min.
+
+import { getStore } from '@netlify/blobs';
+
+const STORE_NAME = 'oracle-es2-auth-rl';
+const MAX_FAILS = 5;
+const BLOCK_MS = 15 * 60 * 1000;
+
+/** IP client depuis un event Netlify (handler classique : headers = objet plat). */
+export function clientIpFromEvent(event) {
+  const h = (event && event.headers) || {};
+  const xf = h['x-forwarded-for'] || h['X-Forwarded-For'] || '';
+  if (xf) return xf.split(',')[0].trim().slice(0, 64) || 'unknown';
+  return (h['x-nf-client-connection-ip'] || 'unknown').slice(0, 64);
+}
+
+/** @returns {Promise<{ blocked: boolean, retryAfterSec?: number }>} */
+export async function checkRateLimit(ip) {
+  const key = `rl:${ip}`;
+  try {
+    const store = getStore(STORE_NAME);
+    const raw = await store.get(key);
+    if (!raw) return { blocked: false };
+    const state = JSON.parse(raw);
+    const blockedUntil = Number(state.blockedUntil) || 0;
+    if (blockedUntil > Date.now()) {
+      return { blocked: true, retryAfterSec: Math.ceil((blockedUntil - Date.now()) / 1000) };
+    }
+    return { blocked: false };
+  } catch {
+    return { blocked: false };
+  }
+}
+
+/** @returns {Promise<{ blocked: boolean, retryAfterSec?: number }>} */
+export async function recordFailure(ip) {
+  const key = `rl:${ip}`;
+  try {
+    const store = getStore(STORE_NAME);
+    const raw = await store.get(key);
+    let fails = 0;
+    let blockedUntil = 0;
+    if (raw) {
+      const state = JSON.parse(raw);
+      fails = Number(state.fails) || 0;
+      blockedUntil = Number(state.blockedUntil) || 0;
+    }
+    if (blockedUntil > Date.now()) {
+      return { blocked: true, retryAfterSec: Math.ceil((blockedUntil - Date.now()) / 1000) };
+    }
+    fails += 1;
+    if (fails >= MAX_FAILS) {
+      blockedUntil = Date.now() + BLOCK_MS;
+      fails = 0;
+    }
+    await store.set(key, JSON.stringify({ fails, blockedUntil }));
+    if (blockedUntil > Date.now()) {
+      return { blocked: true, retryAfterSec: Math.ceil((blockedUntil - Date.now()) / 1000) };
+    }
+    return { blocked: false };
+  } catch {
+    return { blocked: false };
+  }
+}
+
+export async function clearRateLimit(ip) {
+  const key = `rl:${ip}`;
+  try {
+    const store = getStore(STORE_NAME);
+    await store.delete(key);
+  } catch {
+    /* ignore */
+  }
+}

--- a/netlify/functions/lib/oracle-es2-shared.mjs
+++ b/netlify/functions/lib/oracle-es2-shared.mjs
@@ -1,0 +1,108 @@
+// Logique partagée de l'outil /oracle-es2 :
+// - vérification du mot de passe (jamais en dur, vit dans ORACLE_ES2_PASSWORD)
+// - génération d'embedding via OpenAI text-embedding-3-small (1536 dims)
+// - génération du brouillon via l'API Claude (Opus 4.8)
+
+import crypto from 'node:crypto';
+
+/** Compare le mot de passe soumis à ORACLE_ES2_PASSWORD (timing-safe). */
+export function checkPassword(submitted) {
+  const expected = process.env.ORACLE_ES2_PASSWORD;
+  if (!expected) return { ok: false, reason: 'config' };
+  const a = Buffer.from(String(submitted ?? ''));
+  const b = Buffer.from(expected);
+  // timingSafeEqual exige des longueurs égales : on court-circuite proprement.
+  if (a.length !== b.length) return { ok: false, reason: 'invalid' };
+  const valid = crypto.timingSafeEqual(a, b);
+  return { ok: valid, reason: valid ? null : 'invalid' };
+}
+
+/** Embedding de la question via OpenAI. Retourne un tableau de 1536 floats. */
+export async function embedQuestion(text) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) throw new Error('OPENAI_API_KEY manquant');
+
+  const res = await fetch('https://api.openai.com/v1/embeddings', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${key}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: 'text-embedding-3-small',
+      input: text,
+    }),
+  });
+
+  if (!res.ok) {
+    const t = await res.text();
+    throw new Error(`Embedding OpenAI échoué (${res.status}): ${t}`);
+  }
+  const data = await res.json();
+  return data?.data?.[0]?.embedding;
+}
+
+const SYSTEM_PROMPT = `Tu écris des réponses aux bilans des membres premium d'une formation, à la place de leur mentor. Tu imites fidèlement SA voix à partir des exemples fournis.
+
+Style à respecter absolument :
+- Direct, fraternel, franc. Pas de flatterie, pas de langue de bois.
+- Français casual, comme un message d'un grand frère qui maîtrise son sujet.
+- Aucun coaching condescendant, aucune formule creuse de coach.
+- INTERDICTION ABSOLUE du tiret cadratin (—). Ne l'utilise JAMAIS, dans aucun contexte. À la place : des phrases courtes, des virgules, des points, des deux-points ou des parenthèses.
+- Calque le ton, le vocabulaire, la longueur et la façon de penser des exemples fournis.
+
+Quand un exemple contient un raisonnement, sers-t'en pour comprendre la logique de l'angle choisi, pas seulement les mots.
+
+Tu produis uniquement le brouillon de la réponse, prêt à être copié. Pas de préambule, pas de méta-commentaire, pas d'options, pas de tiret cadratin.`;
+
+/** Construit le bloc d'exemples (réponse + raisonnement quand dispo). */
+function formatExamples(examples) {
+  return examples
+    .map((e, i) => {
+      let s = `### Exemple ${i + 1}\nQuestion reçue :\n${e.question}\n\nMa réponse :\n${e.reponse}`;
+      if (e.raisonnement && String(e.raisonnement).trim()) {
+        s += `\n\nMon raisonnement (pourquoi cet angle) :\n${e.raisonnement}`;
+      }
+      return s;
+    })
+    .join('\n\n');
+}
+
+/** Génère le brouillon dans le style perso à partir des exemples les plus proches. */
+export async function generateDraft({ question, examples }) {
+  const key = process.env.ANTHROPIC_API_KEY;
+  if (!key) throw new Error('ANTHROPIC_API_KEY manquant');
+
+  const exBlock = examples.length
+    ? `Voici des exemples de mes réponses passées, les plus proches sémantiquement de la nouvelle question :\n\n${formatExamples(examples)}`
+    : `Je n'ai pas encore d'exemple proche en base. Reste fidèle au style décrit dans tes instructions.`;
+
+  const userContent = `${exBlock}\n\n---\n\nNouvelle question à laquelle répondre dans mon style :\n${question}\n\nÉcris le brouillon de ma réponse. Réponds UNIQUEMENT avec le brouillon, sans préambule ni commentaire.`;
+
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'x-api-key': key,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: 'claude-opus-4-8',
+      max_tokens: 2048,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: userContent }],
+    }),
+  });
+
+  if (!res.ok) {
+    const t = await res.text();
+    throw new Error(`Claude échoué (${res.status}): ${t}`);
+  }
+  const data = await res.json();
+  const text = (data?.content || [])
+    .filter((b) => b.type === 'text')
+    .map((b) => b.text)
+    .join('')
+    .trim();
+  return text;
+}

--- a/netlify/functions/oracle-es2-add.mjs
+++ b/netlify/functions/oracle-es2-add.mjs
@@ -1,0 +1,79 @@
+// POST /api/oracle-es2-add
+// Body : { password, question, reponse, raisonnement? }
+// Stocke la paire + l'embedding de la question. Protégé par mot de passe.
+
+import { checkPassword, embedQuestion } from './lib/oracle-es2-shared.mjs';
+import { supabasePost, supabaseGet } from './lib/supabase-rest.mjs';
+import { clientIpFromEvent, checkRateLimit, recordFailure, clearRateLimit } from './lib/oracle-es2-rate-limit.mjs';
+
+const json = (statusCode, body, extraHeaders = {}) => ({
+  statusCode,
+  headers: { 'Content-Type': 'application/json', ...extraHeaders },
+  body: JSON.stringify(body),
+});
+
+const tooMany = (retryAfterSec) =>
+  json(429, { error: 'Trop de tentatives. Réessaie dans quelques minutes.' }, { 'Retry-After': String(retryAfterSec || 900) });
+
+export const handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return json(405, { error: 'Method not allowed' });
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(event.body || '{}');
+  } catch {
+    return json(400, { error: 'JSON invalide' });
+  }
+
+  const ip = clientIpFromEvent(event);
+  const rl = await checkRateLimit(ip);
+  if (rl.blocked) return tooMany(rl.retryAfterSec);
+
+  const pw = checkPassword(payload.password);
+  if (!pw.ok) {
+    if (pw.reason === 'config') return json(500, { error: 'Configuration serveur manquante' });
+    const rf = await recordFailure(ip);
+    if (rf.blocked) return tooMany(rf.retryAfterSec);
+    return json(401, { error: 'Mot de passe invalide' });
+  }
+  await clearRateLimit(ip);
+
+  const question = (payload.question || '').trim();
+  const reponse = (payload.reponse || '').trim();
+  const raisonnement = (payload.raisonnement || '').trim();
+
+  if (!question || !reponse) {
+    return json(400, { error: 'La question et la réponse sont obligatoires' });
+  }
+
+  try {
+    const embedding = await embedQuestion(question);
+    if (!Array.isArray(embedding) || embedding.length !== 1536) {
+      return json(502, { error: 'Embedding invalide' });
+    }
+
+    const insert = await supabasePost('oracle_es2_entries', {
+      question,
+      reponse,
+      raisonnement: raisonnement || null,
+      // pgvector via PostgREST : le vecteur se passe en chaîne "[...]"
+      embedding: JSON.stringify(embedding),
+    });
+
+    if (!insert.ok) {
+      console.error('❌ oracle-es2-add insert:', insert.error);
+      return json(502, { error: 'Échec enregistrement Supabase' });
+    }
+
+    // Total en base (scan léger, suffisant à cette échelle)
+    const count = await supabaseGet('oracle_es2_entries?select=id');
+    const total = Array.isArray(count.data) ? count.data.length : null;
+
+    return json(200, { ok: true, total });
+  } catch (err) {
+    console.error('❌ oracle-es2-add:', err);
+    return json(500, { error: err.message || 'Erreur interne' });
+  }
+};

--- a/netlify/functions/oracle-es2-generate.mjs
+++ b/netlify/functions/oracle-es2-generate.mjs
@@ -1,0 +1,84 @@
+// POST /api/oracle-es2-generate
+// Body : { password, question }
+// Cherche les réponses passées les plus proches, génère un brouillon dans le style perso.
+// Protégé par mot de passe. N'envoie rien à personne : retourne juste le brouillon.
+
+import { checkPassword, embedQuestion, generateDraft } from './lib/oracle-es2-shared.mjs';
+import { supabasePost } from './lib/supabase-rest.mjs';
+import { clientIpFromEvent, checkRateLimit, recordFailure, clearRateLimit } from './lib/oracle-es2-rate-limit.mjs';
+
+const MATCH_COUNT = 5;
+
+const json = (statusCode, body, extraHeaders = {}) => ({
+  statusCode,
+  headers: { 'Content-Type': 'application/json', ...extraHeaders },
+  body: JSON.stringify(body),
+});
+
+const tooMany = (retryAfterSec) =>
+  json(429, { error: 'Trop de tentatives. Réessaie dans quelques minutes.' }, { 'Retry-After': String(retryAfterSec || 900) });
+
+export const handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return json(405, { error: 'Method not allowed' });
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(event.body || '{}');
+  } catch {
+    return json(400, { error: 'JSON invalide' });
+  }
+
+  const ip = clientIpFromEvent(event);
+  const rl = await checkRateLimit(ip);
+  if (rl.blocked) return tooMany(rl.retryAfterSec);
+
+  const pw = checkPassword(payload.password);
+  if (!pw.ok) {
+    if (pw.reason === 'config') return json(500, { error: 'Configuration serveur manquante' });
+    const rf = await recordFailure(ip);
+    if (rf.blocked) return tooMany(rf.retryAfterSec);
+    return json(401, { error: 'Mot de passe invalide' });
+  }
+  await clearRateLimit(ip);
+
+  const question = (payload.question || '').trim();
+  if (!question) {
+    return json(400, { error: 'La question est obligatoire' });
+  }
+
+  try {
+    const embedding = await embedQuestion(question);
+    if (!Array.isArray(embedding) || embedding.length !== 1536) {
+      return json(502, { error: 'Embedding invalide' });
+    }
+
+    // Recherche sémantique (fonction SQL match_oracle_es2)
+    const match = await supabasePost('rpc/match_oracle_es2', {
+      query_embedding: JSON.stringify(embedding),
+      match_count: MATCH_COUNT,
+    });
+
+    if (!match.ok) {
+      console.error('❌ oracle-es2-generate match:', match.error);
+      return json(502, { error: 'Échec recherche Supabase' });
+    }
+
+    const examples = Array.isArray(match.data) ? match.data : [];
+
+    const draft = await generateDraft({ question, examples });
+
+    return json(200, {
+      ok: true,
+      draft,
+      used: examples.map((e) => ({
+        question: e.question,
+        similarity: typeof e.similarity === 'number' ? Math.round(e.similarity * 1000) / 1000 : null,
+      })),
+    });
+  } catch (err) {
+    console.error('❌ oracle-es2-generate:', err);
+    return json(500, { error: err.message || 'Erreur interne' });
+  }
+};

--- a/sql/oracle_es2.sql
+++ b/sql/oracle_es2.sql
@@ -1,0 +1,52 @@
+-- Oracle ES2 — base de réponses passées pour l'assistant de rédaction /oracle-es2.
+-- Une seule exécution dans Supabase SQL Editor (projet SonnyCourt Main Site).
+-- Accès uniquement via Netlify Functions + service role (RLS active, aucune policy).
+
+-- 1. Extension pgvector (embeddings OpenAI text-embedding-3-small = 1536 dimensions)
+create extension if not exists vector;
+
+-- 2. Table des paires question / réponse (+ raisonnement optionnel)
+create table if not exists public.oracle_es2_entries (
+  id uuid primary key default gen_random_uuid(),
+  question text not null,
+  reponse text not null,
+  raisonnement text,                 -- optionnel : le "pourquoi" de l'angle
+  embedding vector(1536),            -- embedding de la QUESTION
+  created_at timestamptz default now()
+);
+
+comment on table public.oracle_es2_entries is
+  'Réponses passées (style perso) pour l''assistant de rédaction /oracle-es2. Embedding = question. Accès service role uniquement.';
+
+-- 3. RLS active, aucune policy : anon/authenticated bloqués, la service role Netlify bypass RLS.
+alter table public.oracle_es2_entries enable row level security;
+
+-- 4. Recherche sémantique par similarité cosinus.
+--    Pas d'index ivfflat volontairement : à faible volume (~10 à quelques centaines de lignes)
+--    un scan séquentiel est EXACT et rapide. Ajouter un index ivfflat plus tard quand la base grossit :
+--      create index on public.oracle_es2_entries using ivfflat (embedding vector_cosine_ops) with (lists = 100);
+create or replace function public.match_oracle_es2(
+  query_embedding vector(1536),
+  match_count int default 5
+)
+returns table (
+  id uuid,
+  question text,
+  reponse text,
+  raisonnement text,
+  similarity float
+)
+language sql
+stable
+as $$
+  select
+    e.id,
+    e.question,
+    e.reponse,
+    e.raisonnement,
+    1 - (e.embedding <=> query_embedding) as similarity
+  from public.oracle_es2_entries e
+  where e.embedding is not null
+  order by e.embedding <=> query_embedding
+  limit match_count;
+$$;

--- a/src/pages/oracle-es2.astro
+++ b/src/pages/oracle-es2.astro
@@ -1,0 +1,365 @@
+---
+// Oracle ES2 — outil interne de rédaction (assistant style perso).
+// Statique + Netlify Functions. Protégé par mot de passe (ORACLE_ES2_PASSWORD côté serveur).
+---
+
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="color-scheme" content="light only" />
+  <title>Oracle ES2</title>
+  <meta name="description" content="Assistant de rédaction interne." />
+  <meta name="robots" content="noindex, nofollow" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" onload="this.onload=null;this.rel='stylesheet'" />
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" /></noscript>
+
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    :root {
+      color-scheme: light only;
+      --primary: #6d28d9;
+      --primary-dark: #5b21b6;
+      --ink: #0f172a;
+      --ink-soft: #334155;
+      --muted: #64748b;
+      --line: #e2e8f0;
+      --surface: #ffffff;
+      --bg: #f8fafc;
+      --accent-soft: #f5f3ff;
+      --ok: #059669;
+      --err: #dc2626;
+    }
+
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--ink);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .wrap {
+      max-width: 760px;
+      margin: 0 auto;
+      padding: clamp(28px, 5vw, 56px) 20px 64px;
+    }
+
+    .eyebrow {
+      display: inline-block;
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--primary-dark);
+      margin-bottom: 8px;
+    }
+
+    h1 {
+      font-size: clamp(1.5rem, 4vw, 2rem);
+      font-weight: 900;
+      letter-spacing: -0.02em;
+      margin-bottom: 6px;
+    }
+
+    .sub { color: var(--muted); font-size: 0.95rem; margin-bottom: 28px; }
+
+    label { display: block; font-weight: 600; font-size: 0.9rem; margin: 0 0 6px; }
+    .hint { font-weight: 400; color: var(--muted); font-size: 0.82rem; }
+
+    textarea, input[type="password"] {
+      width: 100%;
+      font-family: inherit;
+      font-size: 0.98rem;
+      color: var(--ink);
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      padding: 12px 14px;
+      resize: vertical;
+      transition: border-color .15s, box-shadow .15s;
+    }
+    textarea:focus, input:focus {
+      outline: none;
+      border-color: var(--primary);
+      box-shadow: 0 0 0 3px var(--accent-soft);
+    }
+    textarea { min-height: 90px; }
+    .field { margin-bottom: 18px; }
+
+    button {
+      font-family: inherit;
+      font-weight: 700;
+      font-size: 0.98rem;
+      color: #fff;
+      background: var(--primary);
+      border: none;
+      border-radius: 12px;
+      padding: 13px 22px;
+      cursor: pointer;
+      transition: background .15s, transform .05s;
+    }
+    button:hover { background: var(--primary-dark); }
+    button:active { transform: translateY(1px); }
+    button:disabled { opacity: .55; cursor: not-allowed; }
+
+    .tabs { display: flex; gap: 8px; margin-bottom: 24px; border-bottom: 1px solid var(--line); }
+    .tab {
+      background: none; color: var(--muted); border: none; border-radius: 0;
+      padding: 12px 6px; font-weight: 700; font-size: 0.95rem; cursor: pointer;
+      border-bottom: 2px solid transparent; margin-bottom: -1px;
+    }
+    .tab:hover { background: none; color: var(--ink); }
+    .tab.active { color: var(--primary-dark); border-bottom-color: var(--primary); }
+
+    .panel { display: none; }
+    .panel.active { display: block; }
+
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      padding: clamp(18px, 3vw, 26px);
+      box-shadow: 0 6px 24px rgba(15,23,42,.05);
+    }
+
+    .msg { font-size: 0.9rem; margin-top: 14px; min-height: 1.2em; }
+    .msg.ok { color: var(--ok); }
+    .msg.err { color: var(--err); }
+
+    .draft-box {
+      margin-top: 22px;
+      background: var(--accent-soft);
+      border: 1px solid #ddd6fe;
+      border-radius: 14px;
+      padding: 18px;
+      display: none;
+    }
+    .draft-box.show { display: block; }
+    .draft-text {
+      white-space: pre-wrap;
+      font-size: 0.98rem;
+      color: var(--ink);
+      line-height: 1.7;
+    }
+    .draft-actions { display: flex; align-items: center; gap: 12px; margin-top: 14px; }
+    .copy-btn { background: #fff; color: var(--primary-dark); border: 1px solid #ddd6fe; padding: 9px 16px; font-size: 0.88rem; }
+    .copy-btn:hover { background: #fff; border-color: var(--primary); }
+
+    .used { margin-top: 16px; font-size: 0.82rem; color: var(--muted); }
+    .used ul { margin: 6px 0 0; padding-left: 18px; }
+    .used li { margin-bottom: 3px; }
+
+    /* Gate */
+    .gate {
+      position: fixed; inset: 0; background: var(--bg);
+      display: flex; align-items: center; justify-content: center; padding: 20px; z-index: 50;
+    }
+    .gate-card { width: 100%; max-width: 360px; text-align: center; }
+    .gate-card .card { padding: 28px 24px; }
+    .gate h2 { font-size: 1.2rem; font-weight: 800; margin-bottom: 16px; }
+    .gate input { margin-bottom: 14px; text-align: center; }
+    .gate button { width: 100%; }
+    .app { display: none; }
+    .app.show { display: block; }
+  </style>
+</head>
+<body>
+  <!-- Écran mot de passe -->
+  <div class="gate" id="gate">
+    <div class="gate-card">
+      <div class="card">
+        <h2>🔒 Oracle ES2</h2>
+        <form id="gate-form">
+          <input type="password" id="gate-pw" placeholder="Mot de passe" autocomplete="current-password" autofocus />
+          <button type="submit">Entrer</button>
+        </form>
+        <div class="msg err" id="gate-msg"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Application -->
+  <div class="app" id="app">
+    <div class="wrap">
+      <span class="eyebrow">Outil interne</span>
+      <h1>Oracle ES2</h1>
+      <p class="sub">Ton assistant de rédaction. Plus la base grossit, plus les brouillons te ressemblent.</p>
+
+      <div class="tabs">
+        <button class="tab active" data-tab="feed">Alimenter la base</button>
+        <button class="tab" data-tab="gen">Générer</button>
+      </div>
+
+      <!-- Onglet Alimenter -->
+      <div class="panel active" id="panel-feed">
+        <div class="card">
+          <form id="feed-form">
+            <div class="field">
+              <label for="f-question">Question reçue</label>
+              <textarea id="f-question" placeholder="Le bilan / message du membre…" required></textarea>
+            </div>
+            <div class="field">
+              <label for="f-reponse">Ta réponse</label>
+              <textarea id="f-reponse" placeholder="Ce que tu as répondu, dans ton style…" required style="min-height:140px;"></textarea>
+            </div>
+            <div class="field">
+              <label for="f-raisonnement">Raisonnement <span class="hint">(optionnel : le pourquoi de l'angle, quand t'as un déclic)</span></label>
+              <textarea id="f-raisonnement" placeholder="Pourquoi cet angle plutôt qu'un autre…"></textarea>
+            </div>
+            <button type="submit" id="feed-btn">Enregistrer</button>
+            <div class="msg" id="feed-msg"></div>
+          </form>
+        </div>
+      </div>
+
+      <!-- Onglet Générer -->
+      <div class="panel" id="panel-gen">
+        <div class="card">
+          <form id="gen-form">
+            <div class="field">
+              <label for="g-question">Nouvelle question</label>
+              <textarea id="g-question" placeholder="Le bilan / message auquel répondre…" required style="min-height:120px;"></textarea>
+            </div>
+            <button type="submit" id="gen-btn">Générer le brouillon</button>
+            <div class="msg" id="gen-msg"></div>
+
+            <div class="draft-box" id="draft-box">
+              <div class="draft-text" id="draft-text"></div>
+              <div class="draft-actions">
+                <button type="button" class="copy-btn" id="copy-btn">Copier</button>
+                <span class="msg" id="copy-msg" style="margin-top:0;"></span>
+              </div>
+              <div class="used" id="used-box"></div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script is:inline>
+    (function () {
+      var KEY = 'oracle_es2_pw';
+      var gate = document.getElementById('gate');
+      var app = document.getElementById('app');
+
+      function unlock() { gate.style.display = 'none'; app.classList.add('show'); }
+      function lock(msg) {
+        sessionStorage.removeItem(KEY);
+        app.classList.remove('show');
+        gate.style.display = 'flex';
+        if (msg) document.getElementById('gate-msg').textContent = msg;
+      }
+      function pw() { return sessionStorage.getItem(KEY) || ''; }
+
+      if (pw()) unlock();
+
+      // Le mot de passe n'est validé qu'au premier appel serveur réel.
+      document.getElementById('gate-form').addEventListener('submit', function (e) {
+        e.preventDefault();
+        var val = document.getElementById('gate-pw').value;
+        if (!val) return;
+        sessionStorage.setItem(KEY, val);
+        document.getElementById('gate-msg').textContent = '';
+        unlock();
+      });
+
+      // Onglets
+      document.querySelectorAll('.tab').forEach(function (t) {
+        t.addEventListener('click', function () {
+          document.querySelectorAll('.tab').forEach(function (x) { x.classList.remove('active'); });
+          document.querySelectorAll('.panel').forEach(function (x) { x.classList.remove('active'); });
+          t.classList.add('active');
+          document.getElementById('panel-' + t.dataset.tab).classList.add('active');
+        });
+      });
+
+      function setMsg(el, text, cls) {
+        el.textContent = text;
+        el.className = 'msg' + (cls ? ' ' + cls : '');
+      }
+
+      async function callApi(path, body) {
+        var res = await fetch(path, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(Object.assign({ password: pw() }, body)),
+        });
+        var data = null;
+        try { data = await res.json(); } catch (e) {}
+        if (res.status === 401) { lock('Mot de passe invalide.'); throw new Error('unauthorized'); }
+        if (!res.ok) throw new Error((data && data.error) || ('Erreur ' + res.status));
+        return data;
+      }
+
+      // Alimenter
+      document.getElementById('feed-form').addEventListener('submit', async function (e) {
+        e.preventDefault();
+        var btn = document.getElementById('feed-btn');
+        var msg = document.getElementById('feed-msg');
+        var q = document.getElementById('f-question').value.trim();
+        var r = document.getElementById('f-reponse').value.trim();
+        var rz = document.getElementById('f-raisonnement').value.trim();
+        if (!q || !r) { setMsg(msg, 'Question et réponse obligatoires.', 'err'); return; }
+        btn.disabled = true; setMsg(msg, 'Enregistrement…', '');
+        try {
+          var data = await callApi('/api/oracle-es2-add', { question: q, reponse: r, raisonnement: rz });
+          setMsg(msg, '✅ Enregistré' + (data.total ? ' (' + data.total + ' en base).' : '.'), 'ok');
+          document.getElementById('f-question').value = '';
+          document.getElementById('f-reponse').value = '';
+          document.getElementById('f-raisonnement').value = '';
+        } catch (err) {
+          if (err.message !== 'unauthorized') setMsg(msg, '❌ ' + err.message, 'err');
+        } finally { btn.disabled = false; }
+      });
+
+      // Générer
+      document.getElementById('gen-form').addEventListener('submit', async function (e) {
+        e.preventDefault();
+        var btn = document.getElementById('gen-btn');
+        var msg = document.getElementById('gen-msg');
+        var box = document.getElementById('draft-box');
+        var q = document.getElementById('g-question').value.trim();
+        if (!q) { setMsg(msg, 'Question obligatoire.', 'err'); return; }
+        btn.disabled = true; box.classList.remove('show'); setMsg(msg, 'Génération en cours…', '');
+        try {
+          var data = await callApi('/api/oracle-es2-generate', { question: q });
+          document.getElementById('draft-text').textContent = data.draft || '(vide)';
+          var used = document.getElementById('used-box');
+          if (data.used && data.used.length) {
+            var items = data.used.map(function (u) {
+              var sim = (u.similarity != null) ? ' (' + Math.round(u.similarity * 100) + '%)' : '';
+              var qx = u.question.length > 70 ? u.question.slice(0, 70) + '…' : u.question;
+              return '<li>' + qx.replace(/</g, '&lt;') + sim + '</li>';
+            }).join('');
+            used.innerHTML = 'Appuyé sur ' + data.used.length + ' réponse(s) proche(s) :<ul>' + items + '</ul>';
+          } else {
+            used.innerHTML = 'Aucune réponse proche en base (style générique appliqué).';
+          }
+          box.classList.add('show');
+          setMsg(msg, '', '');
+        } catch (err) {
+          if (err.message !== 'unauthorized') setMsg(msg, '❌ ' + err.message, 'err');
+        } finally { btn.disabled = false; }
+      });
+
+      // Copier
+      document.getElementById('copy-btn').addEventListener('click', function () {
+        var text = document.getElementById('draft-text').textContent;
+        var cm = document.getElementById('copy-msg');
+        navigator.clipboard.writeText(text).then(function () {
+          setMsg(cm, 'Copié ✅', 'ok');
+          setTimeout(function () { setMsg(cm, '', ''); }, 1800);
+        }).catch(function () { setMsg(cm, 'Échec copie', 'err'); });
+      });
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Outil interne protégé par mot de passe pour rédiger les réponses aux bilans des membres premium dans le style perso, à partir d'une base de réponses passées (RAG) qui grossit avec le temps.

## Contenu
- **Page** `/oracle-es2` (statique, noindex) : gate mot de passe + 2 onglets (Alimenter la base / Générer un brouillon).
- **Supabase pgvector** : table `oracle_es2_entries` + fonction `match_oracle_es2` (recherche sémantique, scan exact adapté au faible volume).
- **Embeddings** OpenAI `text-embedding-3-small` (1536 dims).
- **Génération** via l'API Claude (Opus 4.8), style imposé, raisonnement injecté au prompt quand dispo.
- **Rate-limit** anti-brute-force (5 essais/IP → 15 min) via Netlify Blobs, store séparé de l'admin.
- Aucune action vers le prospect : copie manuelle uniquement.

## À faire après merge
1. Exécuter `sql/oracle_es2.sql` une fois dans Supabase.
2. Env vars Netlify : `ORACLE_ES2_PASSWORD`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)