### PR TITLE
feat(oracle-es2): onglet "Ma base" (liste des messages enregistrés)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -62,6 +62,11 @@ publish = "dist"
   status = 200
 
 [[redirects]]
+  from = "/api/oracle-es2-list"
+  to = "/.netlify/functions/oracle-es2-list"
+  status = 200
+
+[[redirects]]
   from = "/api/mailerlite-group-count"
   to = "/.netlify/functions/mailerlite-group-count"
   status = 200

--- a/netlify/functions/oracle-es2-list.mjs
+++ b/netlify/functions/oracle-es2-list.mjs
@@ -1,0 +1,58 @@
+// POST /api/oracle-es2-list
+// Body : { password }
+// Retourne la liste des paires enregistrées (sans l'embedding), récentes d'abord.
+// Protégé par mot de passe + rate-limit, comme les autres endpoints oracle.
+
+import { checkPassword } from './lib/oracle-es2-shared.mjs';
+import { supabaseGet } from './lib/supabase-rest.mjs';
+import { clientIpFromEvent, checkRateLimit, recordFailure, clearRateLimit } from './lib/oracle-es2-rate-limit.mjs';
+
+const json = (statusCode, body, extraHeaders = {}) => ({
+  statusCode,
+  headers: { 'Content-Type': 'application/json', ...extraHeaders },
+  body: JSON.stringify(body),
+});
+
+const tooMany = (retryAfterSec) =>
+  json(429, { error: 'Trop de tentatives. Réessaie dans quelques minutes.' }, { 'Retry-After': String(retryAfterSec || 900) });
+
+export const handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return json(405, { error: 'Method not allowed' });
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(event.body || '{}');
+  } catch {
+    return json(400, { error: 'JSON invalide' });
+  }
+
+  const ip = clientIpFromEvent(event);
+  const rl = await checkRateLimit(ip);
+  if (rl.blocked) return tooMany(rl.retryAfterSec);
+
+  const pw = checkPassword(payload.password);
+  if (!pw.ok) {
+    if (pw.reason === 'config') return json(500, { error: 'Configuration serveur manquante' });
+    const rf = await recordFailure(ip);
+    if (rf.blocked) return tooMany(rf.retryAfterSec);
+    return json(401, { error: 'Mot de passe invalide' });
+  }
+  await clearRateLimit(ip);
+
+  try {
+    const res = await supabaseGet(
+      'oracle_es2_entries?select=id,question,reponse,raisonnement,created_at&order=created_at.desc'
+    );
+    if (!res.ok) {
+      console.error('❌ oracle-es2-list:', res.error);
+      return json(502, { error: 'Échec lecture Supabase' });
+    }
+    const entries = Array.isArray(res.data) ? res.data : [];
+    return json(200, { ok: true, total: entries.length, entries });
+  } catch (err) {
+    console.error('❌ oracle-es2-list:', err);
+    return json(500, { error: err.message || 'Erreur interne' });
+  }
+};

--- a/src/pages/oracle-es2.astro
+++ b/src/pages/oracle-es2.astro
@@ -121,6 +121,17 @@
     .panel { display: none; }
     .panel.active { display: block; }
 
+    .tab-count {
+      display: inline-block; min-width: 18px; padding: 0 5px; margin-left: 2px;
+      font-size: 0.72rem; line-height: 17px; text-align: center;
+      background: var(--accent-soft); color: var(--primary-dark);
+      border-radius: 9px; font-weight: 800; vertical-align: middle;
+    }
+    .tab-count:empty { display: none; }
+
+    .base-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 14px; gap: 12px; }
+    .base-count { font-weight: 800; font-size: 1.05rem; }
+
     .card {
       background: var(--surface);
       border: 1px solid var(--line);
@@ -169,6 +180,23 @@
     .app { display: none; }
     .app.show { display: block; }
   </style>
+
+  <!-- Styles des éléments créés en JS (la liste) : globaux, sinon le scope Astro ne s'applique pas -->
+  <style is:global>
+    #base-count span { color: #64748b; font-weight: 600; font-size: 0.9rem; }
+    #base-list .entry {
+      background: #ffffff; border: 1px solid #e2e8f0; border-radius: 14px;
+      padding: 14px 16px; margin-bottom: 12px;
+    }
+    #base-list .entry-q { font-weight: 700; font-size: 0.96rem; margin-bottom: 6px; color: #0f172a; }
+    #base-list .entry-r { color: #334155; font-size: 0.9rem; white-space: pre-wrap; }
+    #base-list .entry-r.clamp { display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+    #base-list .entry-meta { display: flex; align-items: center; gap: 10px; margin-top: 8px; font-size: 0.78rem; color: #64748b; flex-wrap: wrap; }
+    #base-list .entry-meta .has-r { color: #5b21b6; font-weight: 700; }
+    #base-list .entry-toggle { background: none; border: none; color: #5b21b6; font-size: 0.78rem; font-weight: 700; cursor: pointer; padding: 0; }
+    #base-list .entry-toggle:hover { text-decoration: underline; }
+    #base-list .empty { color: #64748b; font-size: 0.92rem; padding: 8px 2px; }
+  </style>
 </head>
 <body>
   <!-- Écran mot de passe -->
@@ -194,6 +222,7 @@
 
       <div class="tabs">
         <button class="tab active" data-tab="feed">Alimenter la base</button>
+        <button class="tab" data-tab="base">Ma base <span class="tab-count" id="tab-count"></span></button>
         <button class="tab" data-tab="gen">Générer</button>
       </div>
 
@@ -217,6 +246,16 @@
             <div class="msg" id="feed-msg"></div>
           </form>
         </div>
+      </div>
+
+      <!-- Onglet Ma base -->
+      <div class="panel" id="panel-base">
+        <div class="base-head">
+          <div class="base-count" id="base-count">…</div>
+          <button type="button" class="copy-btn" id="base-refresh">Rafraîchir</button>
+        </div>
+        <div class="msg" id="base-msg"></div>
+        <div id="base-list"></div>
       </div>
 
       <!-- Onglet Générer -->
@@ -278,8 +317,71 @@
           document.querySelectorAll('.panel').forEach(function (x) { x.classList.remove('active'); });
           t.classList.add('active');
           document.getElementById('panel-' + t.dataset.tab).classList.add('active');
+          if (t.dataset.tab === 'base') loadBase();
         });
       });
+
+      function esc(s) {
+        return String(s == null ? '' : s).replace(/[&<>]/g, function (c) {
+          return c === '&' ? '&amp;' : c === '<' ? '&lt;' : '&gt;';
+        });
+      }
+      function fmtDate(iso) {
+        try {
+          return new Date(iso).toLocaleDateString('fr-FR', { day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' });
+        } catch (e) { return ''; }
+      }
+
+      var baseLoading = false;
+      async function loadBase() {
+        if (baseLoading) return;
+        baseLoading = true;
+        var msg = document.getElementById('base-msg');
+        var list = document.getElementById('base-list');
+        var count = document.getElementById('base-count');
+        count.textContent = 'Chargement…';
+        setMsg(msg, '', '');
+        try {
+          var data = await callApi('/api/oracle-es2-list', {});
+          var entries = data.entries || [];
+          document.getElementById('tab-count').textContent = entries.length ? String(entries.length) : '';
+          count.innerHTML = entries.length
+            ? entries.length + ' message' + (entries.length > 1 ? 's' : '') + ' <span>enregistré' + (entries.length > 1 ? 's' : '') + '</span>'
+            : 'Base vide';
+          if (!entries.length) {
+            list.innerHTML = '<div class="empty">Aucun message pour l\'instant. Va dans « Alimenter la base » pour en ajouter.</div>';
+            return;
+          }
+          list.innerHTML = entries.map(function (e) {
+            var hasR = e.raisonnement && String(e.raisonnement).trim();
+            return '<div class="entry">' +
+              '<div class="entry-q">' + esc(e.question) + '</div>' +
+              '<div class="entry-r clamp">' + esc(e.reponse) + '</div>' +
+              '<div class="entry-meta">' +
+                '<span>' + esc(fmtDate(e.created_at)) + '</span>' +
+                (hasR ? '<span class="has-r">+ raisonnement</span>' : '') +
+                '<button type="button" class="entry-toggle">Voir tout</button>' +
+              '</div>' +
+            '</div>';
+          }).join('');
+          list.querySelectorAll('.entry-toggle').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+              var r = btn.closest('.entry').querySelector('.entry-r');
+              var clamped = r.classList.toggle('clamp');
+              btn.textContent = clamped ? 'Voir tout' : 'Réduire';
+            });
+          });
+        } catch (err) {
+          if (err.message !== 'unauthorized') {
+            setMsg(msg, '❌ ' + err.message, 'err');
+            count.textContent = '';
+          }
+        } finally {
+          baseLoading = false;
+        }
+      }
+
+      document.getElementById('base-refresh').addEventListener('click', loadBase);
 
       function setMsg(el, text, cls) {
         el.textContent = text;
@@ -311,10 +413,12 @@
         btn.disabled = true; setMsg(msg, 'Enregistrement…', '');
         try {
           var data = await callApi('/api/oracle-es2-add', { question: q, reponse: r, raisonnement: rz });
-          setMsg(msg, '✅ Enregistré' + (data.total ? ' (' + data.total + ' en base).' : '.'), 'ok');
+          setMsg(msg, '✅ Enregistré' + (data.total ? ' (' + data.total + ' en base). Visible dans « Ma base ».' : '.'), 'ok');
           document.getElementById('f-question').value = '';
           document.getElementById('f-reponse').value = '';
           document.getElementById('f-raisonnement').value = '';
+          if (data.total) document.getElementById('tab-count').textContent = String(data.total);
+          loadBase();
         } catch (err) {
           if (err.message !== 'unauthorized') setMsg(msg, '❌ ' + err.message, 'err');
         } finally { btn.disabled = false; }


### PR DESCRIPTION
Ajoute un onglet **Ma base** entre "Alimenter la base" et "Générer" : liste des messages enregistrés (récents d'abord), compteur, date, badge raisonnement, troncature 3 lignes + "Voir tout". Se rafraîchit après chaque enregistrement.

- `oracle-es2-list.mjs` : endpoint protégé (mot de passe + rate-limit), renvoie les entrées sans embedding.
- Redirect `/api/oracle-es2-list`.
- Styles des éléments injectés en JS en `is:global` (le scope Astro ne s'applique pas aux nœuds créés au runtime).

Aucune nouvelle variable d'env → pas d'impact sur la limite 4 Ko Lambda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)