### PR TITLE
fix(webinaire): sauter les 9 et 23 juillet (prochaines sessions 16 et 30)

### DIFF
--- a/netlify/functions/lib/webinaire-session-paris.mjs
+++ b/netlify/functions/lib/webinaire-session-paris.mjs
@@ -43,7 +43,7 @@ function getParisWeekdayNumber(parts) {
  * Format: YYYY-MM-DD (date Paris du jeudi de session).
  * Pour ajouter/supprimer un skip, modifier simplement ce tableau.
  */
-const SKIP_SESSION_DATES = ['2026-05-07', '2026-06-11', '2026-06-25'];
+const SKIP_SESSION_DATES = ['2026-05-07', '2026-06-11', '2026-06-25', '2026-07-09', '2026-07-23'];
 
 /** Ajoute des jours au calendrier en passant par une date UTC midi (évite dérives). */
 export function addDaysParisCalendar(year, month, day, deltaDays) {

--- a/src/pages/masterclass.astro
+++ b/src/pages/masterclass.astro
@@ -1596,7 +1596,7 @@ import GAConsentMode from '../components/GAConsentMode.astro';
         const CALL_CONSENT_TEXT = "J'accepte d'être recontacté par l'équipe de Sonny Court au sujet de la masterclass. Y compris par téléphone, en soirée et le week-end. Révocable à tout moment.";
         function getCallConsent() { var c = document.getElementById('call-consent'); return !!(c && c.checked); }
         function getCallConsentText() { var m = document.querySelector('.consent-row__text'); var d = document.querySelector('.consent-more__text'); var t = ((m ? m.textContent.trim() : '') + ' ' + (d ? d.textContent.trim() : '')).trim(); return t || CALL_CONSENT_TEXT; }
-        const SKIP_SESSION_DATES = ['2026-05-07', '2026-06-11', '2026-06-25'];
+        const SKIP_SESSION_DATES = ['2026-05-07', '2026-06-11', '2026-06-25', '2026-07-09', '2026-07-23'];
         const LEGACY_TOKEN_KEY = 'webinaire_es2_token';
         const COOKIE_MAX = 365 * 24 * 60 * 60;
         const STEP3_SUBMIT_LABEL = 'Confirmer mon inscription';

--- a/src/pages/meta/masterclass.astro
+++ b/src/pages/meta/masterclass.astro
@@ -1509,7 +1509,7 @@ import GAConsentMode from '../../components/GAConsentMode.astro';
         const CALL_CONSENT_TEXT = "J'accepte d'être recontacté par l'équipe de Sonny Court au sujet de la masterclass. Y compris par téléphone, en soirée et le week-end. Révocable à tout moment.";
         function getCallConsent() { var c = document.getElementById('call-consent'); return !!(c && c.checked); }
         function getCallConsentText() { var m = document.querySelector('.consent-row__text'); var d = document.querySelector('.consent-more__text'); var t = ((m ? m.textContent.trim() : '') + ' ' + (d ? d.textContent.trim() : '')).trim(); return t || CALL_CONSENT_TEXT; }
-        const SKIP_SESSION_DATES = ['2026-05-07', '2026-06-11'];
+        const SKIP_SESSION_DATES = ['2026-05-07', '2026-06-11', '2026-06-25', '2026-07-09', '2026-07-23'];
         const LEGACY_TOKEN_KEY = 'webinaire_es2_token';
         const COOKIE_MAX = 365 * 24 * 60 * 60;
         const STEP3_SUBMIT_LABEL = 'Confirmer mon inscription';

--- a/src/pages/tt/masterclass.astro
+++ b/src/pages/tt/masterclass.astro
@@ -1502,7 +1502,7 @@ import GAConsentMode from '../../components/GAConsentMode.astro';
         const CALL_CONSENT_TEXT = "J'accepte d'être recontacté par l'équipe de Sonny Court au sujet de la masterclass. Y compris par téléphone, en soirée et le week-end. Révocable à tout moment.";
         function getCallConsent() { var c = document.getElementById('call-consent'); return !!(c && c.checked); }
         function getCallConsentText() { var m = document.querySelector('.consent-row__text'); var d = document.querySelector('.consent-more__text'); var t = ((m ? m.textContent.trim() : '') + ' ' + (d ? d.textContent.trim() : '')).trim(); return t || CALL_CONSENT_TEXT; }
-        const SKIP_SESSION_DATES = ['2026-05-07', '2026-06-11'];
+        const SKIP_SESSION_DATES = ['2026-05-07', '2026-06-11', '2026-06-25', '2026-07-09', '2026-07-23'];
         const LEGACY_TOKEN_KEY = 'webinaire_es2_token';
         const COOKIE_MAX = 365 * 24 * 60 * 60;
         const STEP3_SUBMIT_LABEL = 'Confirmer mon inscription';


### PR DESCRIPTION
Urgent : les opt-ins s'inscrivaient au 9 juillet (session inexistante, bi-weekly). Ajout 2026-07-09 + 2026-07-23 aux SKIP_SESSION_DATES, 4 copies resynchronisées. 🤖 Generated with [Claude Code](https://claude.com/claude-code)