### PR TITLE
feat(console): lien "Séquence emails" (doc post-webinaire) dans la nav closers

### DIFF
--- a/src/pages/closer-console.astro
+++ b/src/pages/closer-console.astro
@@ -1584,6 +1584,11 @@ import GAConsentMode from '../components/GAConsentMode.astro';
                         <span class="cc-nav-label">Guide Spiffy</span>
                         <span class="cc-nav-ext"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg></span>
                     </a>
+                    <a class="cc-nav-link" href="https://docs.google.com/document/d/1WCJQCmqGiB1rU2ufIJCqRjMVnFnih5oW6qrZ6gRtcsg/edit?usp=sharing" target="_blank" rel="noopener noreferrer" title="Séquence d'emails automatique post-webinaire — savoir où le prospect en est (nouvel onglet)">
+                        <span class="cc-nav-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg></span>
+                        <span class="cc-nav-label">Séquence emails</span>
+                        <span class="cc-nav-ext"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg></span>
+                    </a>
                     <a class="cc-nav-link" href="https://sonnycourt.spiffy.co/manage/affiliate/login" target="_blank" rel="noopener noreferrer" title="Portail Spiffy (nouvel onglet)">
                         <span class="cc-nav-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="5" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/></svg></span>
                         <span class="cc-nav-label">Portail Spiffy</span>


### PR DESCRIPTION
Ajout d'un lien Google Doc (séquence email auto post-webi) dans la nav de la console closer, pour que le closer sache où le prospect en est. Aucune autre modification. 🤖 Generated with [Claude Code](https://claude.com/claude-code)