### PR TITLE
Corriger le chargement du design Pay

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -26,8 +26,50 @@ ignore = "node scripts/block-netlify-auto-build.mjs"
   force = true
 
 [[redirects]]
-  from = "https://pay.sonnycourt.com/*"
-  to = "/pay/:splat"
+  from = "https://pay.sonnycourt.com/checkouts"
+  to = "/pay/checkouts"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "https://pay.sonnycourt.com/checkouts/*"
+  to = "/pay/checkouts/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "https://pay.sonnycourt.com/transactions"
+  to = "/pay/transactions"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "https://pay.sonnycourt.com/transactions/*"
+  to = "/pay/transactions/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "https://pay.sonnycourt.com/products"
+  to = "/pay/products"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "https://pay.sonnycourt.com/products/*"
+  to = "/pay/products/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "https://pay.sonnycourt.com/settings"
+  to = "/pay/settings"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "https://pay.sonnycourt.com/settings/*"
+  to = "/pay/settings/:splat"
   status = 200
   force = true
 


### PR DESCRIPTION
Corrige la règle du sous-domaine Pay qui interceptait les fichiers CSS. Les routes de l’application restent accessibles sur pay.sonnycourt.com, tandis que les ressources visuelles sont désormais servies normalement.