### PR TITLE
Corriger l’affichage des transactions Stripe

### DIFF
--- a/src/pages/pay/index.astro
+++ b/src/pages/pay/index.astro
@@ -133,7 +133,7 @@ import PayAppShell from '../../components/PayAppShell.astro';
   } catch {}
 </script>
 
-<style>
+<style is:global>
   .dashboard-kpis { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 13px; }
   .metric-card { min-height: 160px; padding: 19px; }
   .metric-card--primary { border-color: rgba(105, 215, 255, .28); background: radial-gradient(circle at 12% 0%, rgba(112,231,255,.16), transparent 38%), linear-gradient(145deg, rgba(24, 72, 106, .75), rgba(8, 25, 43, .62)); }

--- a/src/pages/pay/transactions.astro
+++ b/src/pages/pay/transactions.astro
@@ -214,7 +214,7 @@ const transactions = [
   stripeTransactionsPromise?.then(renderStripeTransactions);
 </script>
 
-<style>
+<style is:global>
   .transaction-summary { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 12px; margin-bottom: 12px; }
   .transaction-summary article { padding: 18px; }
   .transaction-summary small, .transaction-summary strong, .transaction-summary span { display: block; }


### PR DESCRIPTION
Corrige la perte de mise en forme lorsque les données Stripe réelles remplacent les lignes de démonstration. Applique aussi le correctif à l’activité dynamique du tableau de bord Pay.