### PR TITLE
Créer le logo électrique de Pay

### DIFF
--- a/src/components/PayAppShell.astro
+++ b/src/components/PayAppShell.astro
@@ -29,7 +29,7 @@ const navigation = [
     <section class="pay-login" id="payLogin" aria-labelledby="payLoginTitle">
       <div class="pay-login-glow"></div>
       <div class="pay-login-card pay-glass">
-        <div class="pay-brand pay-brand--login"><span class="pay-brand-mark">P</span><span>PAY</span></div>
+        <div class="pay-brand pay-brand--login"><span class="pay-brand-mark" aria-hidden="true"><span class="pay-logo-letter">P</span><span class="pay-logo-bolt"></span></span><span>PAY</span></div>
         <p class="pay-kicker">Sonny Court · espace privé</p>
         <h1 id="payLoginTitle">Ton cockpit de paiement.</h1>
         <p>Connecte-toi avec le même accès que le Hub pour ouvrir Pay.</p>
@@ -55,7 +55,7 @@ const navigation = [
 
       <aside class="pay-sidebar pay-glass" id="paySidebar">
         <a class="pay-brand" data-pay-route="/" href="/pay">
-          <span class="pay-brand-mark">P</span>
+          <span class="pay-brand-mark" aria-hidden="true"><span class="pay-logo-letter">P</span><span class="pay-logo-bolt"></span></span>
           <span>PAY</span>
           <span class="pay-brand-status">MVP</span>
         </a>
@@ -258,7 +258,11 @@ const navigation = [
   .pay-login-card { width: min(455px, 100%); position: relative; padding: 42px; border-radius: 34px; }
   .pay-brand { display: inline-flex; align-items: center; gap: 10px; color: #fff; font-size: 16px; font-weight: 820; letter-spacing: .12em; text-decoration: none; }
   .pay-brand--login { margin-bottom: 38px; }
-  .pay-brand-mark { width: 38px; height: 38px; display: grid; place-items: center; border: 1px solid rgba(126, 220, 255, .38); border-radius: 13px; background: linear-gradient(145deg, rgba(95, 203, 255, .32), rgba(20, 119, 224, .15)); box-shadow: inset 0 1px rgba(255,255,255,.24), 0 10px 28px rgba(0, 129, 255, .18); font-size: 17px; letter-spacing: 0; }
+  .pay-brand-mark { width: 38px; height: 38px; position: relative; display: grid; flex: 0 0 auto; place-items: center; overflow: hidden; isolation: isolate; border: 1px solid rgba(142, 229, 255, .48); border-radius: 13px; background: radial-gradient(circle at 24% 12%, rgba(255,255,255,.28), transparent 38%), linear-gradient(145deg, rgba(58, 181, 245, .48), rgba(14, 78, 157, .3)); box-shadow: inset 0 1px rgba(255,255,255,.28), inset 0 -1px rgba(18, 188, 255, .12), 0 10px 28px rgba(0, 129, 255, .22); letter-spacing: 0; }
+  .pay-brand-mark::before { content: ""; position: absolute; z-index: -1; width: 47px; height: 15px; top: -8px; left: -15px; transform: rotate(-32deg); background: linear-gradient(90deg, transparent, rgba(255,255,255,.3), transparent); }
+  .pay-brand-mark::after { content: ""; position: absolute; z-index: -1; inset: 5px; border: 1px solid rgba(178, 237, 255, .08); border-radius: 9px; }
+  .pay-logo-letter { position: relative; z-index: 1; margin-left: -4px; color: #f8fdff; font-size: 20px; font-weight: 900; line-height: 1; letter-spacing: -.08em; text-shadow: 0 2px 12px rgba(228, 249, 255, .28); }
+  .pay-logo-bolt { width: 9px; height: 20px; position: absolute; z-index: 2; top: 8px; left: 20px; transform: rotate(4deg); background: linear-gradient(180deg, #eaffff 0%, #72edff 42%, #20bce9 100%); clip-path: polygon(45% 0, 100% 0, 68% 39%, 100% 39%, 24% 100%, 43% 57%, 6% 57%); -webkit-clip-path: polygon(45% 0, 100% 0, 68% 39%, 100% 39%, 24% 100%, 43% 57%, 6% 57%); filter: drop-shadow(0 0 5px rgba(83, 224, 255, .7)); }
   .pay-brand-status { padding: 4px 7px; border: 1px solid rgba(112, 231, 255, .25); border-radius: 999px; color: var(--pay-cyan); background: rgba(112, 231, 255, .08); font-size: 8px; letter-spacing: .12em; }
   .pay-login h1 { margin: 8px 0 12px; font-size: clamp(32px, 7vw, 47px); line-height: .98; letter-spacing: -.055em; }
   .pay-login-card > p:not(.pay-kicker) { margin: 0 0 28px; color: var(--pay-soft); font-size: 14px; line-height: 1.55; }


### PR DESCRIPTION
Remplace le P brut par un monogramme P + éclair, conçu en CSS pour rester net à toutes les tailles. Le logo apparaît sur la connexion et dans la navigation Pay.