### PR TITLE
Fix Meta tracking across the MC2 funnel

### DIFF
--- a/netlify/functions/lib/mc2-meta-events.mjs
+++ b/netlify/functions/lib/mc2-meta-events.mjs
@@ -1,0 +1,162 @@
+import { sendMetaEvent } from './meta-capi.mjs';
+
+const META_SOURCE = 'meta_ad';
+const DEFAULT_VIDEO_DURATION_SECONDS = 5717;
+const VIDEO_MILESTONES = [25, 50, 75];
+
+function clean(value, max = 500) {
+  return String(value == null ? '' : value).trim().slice(0, max);
+}
+
+function positiveNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : 0;
+}
+
+function registrationToken(registration) {
+  return clean(registration?.token, 128);
+}
+
+export function isMc2MetaRegistration(registration) {
+  return clean(registration?.traffic_source, 40).toLowerCase() === META_SOURCE;
+}
+
+export function mc2MetaEventId(stage, token) {
+  const safeStage = clean(stage, 64).toLowerCase().replace(/[^a-z0-9_-]+/g, '-');
+  const safeToken = registrationToken({ token }).replace(/[^a-zA-Z0-9_-]+/g, '');
+  return safeStage && safeToken ? `mc2-${safeStage}-${safeToken}` : null;
+}
+
+export function mc2RegistrationMetaEvents(registration, { created = false, completedNow = false } = {}) {
+  if (!isMc2MetaRegistration(registration)) return [];
+  const token = registrationToken(registration);
+  if (!token) return [];
+  const events = [];
+  if (created) {
+    events.push({
+      eventName: 'EmailCaptured',
+      eventId: mc2MetaEventId('email', token),
+      contentName: 'Masterclass ES2 - Email',
+    });
+  }
+  if (completedNow) {
+    events.push({
+      eventName: 'Lead',
+      eventId: clean(registration.meta_event_id, 255) || mc2MetaEventId('lead', token),
+      contentName: 'Masterclass ES2',
+    });
+  }
+  return events;
+}
+
+function progressPercent(value, meta = {}) {
+  const explicit = positiveNumber(meta.percent);
+  if (explicit) return Math.min(100, explicit);
+  const minutes = positiveNumber(value);
+  const durationSeconds = positiveNumber(meta.duration_seconds) || DEFAULT_VIDEO_DURATION_SECONDS;
+  return Math.min(100, (minutes * 60 * 100) / durationSeconds);
+}
+
+function previousProgressPercent(row, meta = {}) {
+  const minutes = positiveNumber(row?.watch_max_minutes);
+  const durationSeconds = positiveNumber(meta.duration_seconds) || DEFAULT_VIDEO_DURATION_SECONDS;
+  return Math.min(100, (minutes * 60 * 100) / durationSeconds);
+}
+
+export function mc2FunnelMetaEvents({ eventName, value, meta = {}, registration } = {}) {
+  if (!isMc2MetaRegistration(registration)) return [];
+  const token = registrationToken(registration);
+  if (!token) return [];
+
+  if (eventName === 'session_joined' && !registration.attended_live) {
+    return [{
+      eventName: 'QualifiedLead',
+      eventId: mc2MetaEventId('qualified', token),
+      contentName: 'Masterclass ES2 - Présent',
+    }];
+  }
+
+  if (eventName === 'video_checkpoint') {
+    const before = previousProgressPercent(registration, meta);
+    const after = progressPercent(value, meta);
+    return VIDEO_MILESTONES
+      .filter((milestone) => before < milestone && after >= milestone)
+      .map((milestone) => ({
+        eventName: `QualifiedView${milestone}`,
+        eventId: mc2MetaEventId(`view-${milestone}`, token),
+        contentName: `Masterclass ES2 - ${milestone}%`,
+      }));
+  }
+
+  if (eventName === 'cta_reached' && !registration.saw_offer) {
+    return [{
+      eventName: 'OfferViewed',
+      eventId: mc2MetaEventId('offer', token),
+      contentName: 'Masterclass ES2 - Offre',
+    }];
+  }
+
+  if (eventName === 'cta_clicked' && !registration.clicked_cta) {
+    return [{
+      eventName: 'CTA_Clicked',
+      eventId: mc2MetaEventId('cta', token),
+      contentName: 'Masterclass ES2 - CTA',
+    }];
+  }
+
+  if (eventName === 'checkout_viewed' && Number(registration.checkout_view_count || 0) === 0) {
+    return [{
+      eventName: 'InitiateCheckout',
+      eventId: mc2MetaEventId('checkout', token),
+      contentName: 'Esprit Subconscient 2.0',
+    }];
+  }
+
+  return [];
+}
+
+export function mc2MetaRequestContext(req, pagePath) {
+  const headers = req?.headers;
+  const forwarded = clean(headers?.get?.('x-forwarded-for'), 500).split(',')[0].trim();
+  const ip = clean(headers?.get?.('x-nf-client-connection-ip'), 80) || forwarded || null;
+  const userAgent = clean(headers?.get?.('user-agent'), 1000) || null;
+  const referer = clean(headers?.get?.('referer'), 1000);
+  let url = referer || null;
+  try {
+    const base = new URL(referer || req?.url || 'https://sonnycourt.com/');
+    url = pagePath ? new URL(pagePath, base.origin).toString() : base.toString();
+  } catch {
+    url = pagePath ? `https://sonnycourt.com${String(pagePath).startsWith('/') ? '' : '/'}${pagePath}` : null;
+  }
+  return { ip, userAgent, url };
+}
+
+export async function sendMc2MetaEvents({
+  events,
+  registration,
+  req,
+  pagePath,
+  value,
+  currency,
+  eventTime,
+} = {}) {
+  if (!isMc2MetaRegistration(registration) || !Array.isArray(events) || events.length === 0) return [];
+  const context = mc2MetaRequestContext(req, pagePath);
+  return Promise.all(events.map((event) => sendMetaEvent({
+    eventName: event.eventName,
+    eventId: event.eventId,
+    email: registration.email,
+    phone: registration.telephone,
+    externalId: registration.token,
+    ip: context.ip,
+    userAgent: context.userAgent,
+    fbc: registration.meta_fbc,
+    fbp: registration.meta_fbp,
+    url: context.url,
+    eventTime,
+    value,
+    currency,
+    contentName: event.contentName,
+    optinVariant: registration.optin_variant,
+  })));
+}

--- a/netlify/functions/lib/mc2-pay-router.mjs
+++ b/netlify/functions/lib/mc2-pay-router.mjs
@@ -21,6 +21,7 @@ import {
 } from './mc2-circle-onboarding.mjs';
 import { addMc2BuyerToMailerLite } from './mc2-mailerlite-buyers.mjs';
 import { queueMc2ContractDocument } from './mc2-contract-documents.mjs';
+import { mc2MetaEventId, sendMc2MetaEvents } from './mc2-meta-events.mjs';
 import {
   cancelMc2DunningJobs,
   mc2DunningStage,
@@ -201,6 +202,28 @@ async function processCheckoutCompleted(stripe, session, event) {
     last_event_at: nowIso,
   });
   if (!updated.ok) throw new Error(`mc2_purchase_update_${updated.status}`);
+  try {
+    const purchaseRegistration = {
+      ...registration,
+      email: registration.email || session.customer_details?.email || session.customer_email,
+      telephone: registration.telephone || session.customer_details?.phone,
+    };
+    await sendMc2MetaEvents({
+      events: [{
+        eventName: 'Purchase',
+        eventId: mc2MetaEventId('purchase', session.id),
+        contentName: 'Esprit Subconscient 2.0',
+      }],
+      registration: purchaseRegistration,
+      pagePath: '/commencer/succes/',
+      eventTime: Number(event.created) || undefined,
+      value: Number(session.amount_total || MC2_ENTRY_PAYMENT_CENTS) / 100,
+      currency: String(session.currency || 'eur').toUpperCase(),
+    });
+  } catch (error) {
+    // Seul Stripe confirme l'achat ; Meta ne doit jamais bloquer le webhook.
+    console.error('MC2 Meta Purchase failed:', error?.message || error);
+  }
   // Le document est figé uniquement après confirmation du paiement initial.
   // Son insertion est idempotente par inscription ; une rediffusion Stripe ne
   // crée ni nouveau document ni nouveau lien personnel.

--- a/netlify/functions/lib/meta-capi.mjs
+++ b/netlify/functions/lib/meta-capi.mjs
@@ -42,6 +42,7 @@ function hashPhone(phone) {
  * @param {string} [p.eventId]            - id de déduplication (doit matcher le pixel navigateur)
  * @param {string} [p.email]
  * @param {string} [p.phone]
+ * @param {string} [p.externalId]         - identifiant interne stable (hashé avant envoi)
  * @param {string} [p.ip]
  * @param {string} [p.userAgent]
  * @param {string} [p.fbc]               - cookie _fbc (ou reconstruit depuis fbclid)
@@ -56,6 +57,11 @@ function hashPhone(phone) {
 export async function sendMetaEvent(p = {}) {
   const accessToken = process.env.META_ACCESS_TOKEN;
   const pixelId = process.env.META_PIXEL_ID;
+  const deployContext = String(process.env.CONTEXT || '').trim().toLowerCase();
+
+  if (deployContext && deployContext !== 'production' && process.env.META_CAPI_ALLOW_NON_PRODUCTION !== 'true') {
+    return { ok: false, skipped: true, reason: 'non_production' };
+  }
 
   if (!accessToken || !pixelId) {
     console.warn('Meta CAPI: META_ACCESS_TOKEN ou META_PIXEL_ID manquant, event ignoré');
@@ -68,8 +74,10 @@ export async function sendMetaEvent(p = {}) {
   const userData = {};
   const hEmail = hashEmail(p.email);
   const hPhone = hashPhone(p.phone);
+  const hExternalId = p.externalId ? sha256(String(p.externalId).trim()) : undefined;
   if (hEmail) userData.em = [hEmail];
   if (hPhone) userData.ph = [hPhone];
+  if (hExternalId) userData.external_id = [hExternalId];
   if (p.ip) userData.client_ip_address = String(p.ip);
   if (p.userAgent) userData.client_user_agent = String(p.userAgent);
   if (p.fbc) userData.fbc = String(p.fbc);
@@ -104,11 +112,14 @@ export async function sendMetaEvent(p = {}) {
 
   const endpoint = `https://graph.facebook.com/${META_API_VERSION}/${pixelId}/events`;
 
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 3500);
   try {
     const res = await fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
+      signal: controller.signal,
     });
     const json = await res.json().catch(() => ({}));
     // Meta renvoie { events_received: N } en cas de succès, { error: {...} } sinon.
@@ -120,5 +131,7 @@ export async function sendMetaEvent(p = {}) {
   } catch (err) {
     console.error('Meta CAPI fetch error:', err);
     return { ok: false, error: String(err) };
+  } finally {
+    clearTimeout(timeout);
   }
 }

--- a/netlify/functions/mc2-replay-track.js
+++ b/netlify/functions/mc2-replay-track.js
@@ -1,6 +1,10 @@
 import { loadMc2ReplayAccess } from './lib/mc2-replay-recovery.mjs';
 import { supabasePatch, supabasePost } from './lib/supabase-rest.mjs';
 import { ensureMc2OfferDeadline } from './lib/mc2-offer-deadline.mjs';
+import {
+  mc2FunnelMetaEvents,
+  sendMc2MetaEvents,
+} from './lib/mc2-meta-events.mjs';
 
 const EVENTS = new Set(['replay_started', 'replay_progress', 'cta_reached']);
 
@@ -25,6 +29,8 @@ export default async (req) => {
     const access = await loadMc2ReplayAccess(body.access);
     if (!access.ok) return json(404, { error: 'Accès invalide' });
     const currentSecond = second(body.currentSecond);
+    const percent = second(body.percent);
+    const durationSeconds = second(body.duration_seconds);
     const nowIso = new Date().toISOString();
     const patch = { last_presence_at: nowIso, last_event_at: nowIso };
     let offerDeadline = null;
@@ -46,16 +52,40 @@ export default async (req) => {
         { watch_max_seconds_replay: currentSecond, last_presence_at: nowIso, last_event_at: nowIso },
       );
     }
+    const funnelEventName = event === 'replay_progress' ? 'video_checkpoint' : event;
+    const eventMeta = {
+      route: '/mc2/replay/',
+      ...(percent > 0 ? { percent: Math.min(100, percent) } : {}),
+      ...(durationSeconds > 0 ? { duration_seconds: durationSeconds } : {}),
+    };
     await supabasePost('mc2_funnel_events', {
       token: access.registration.token,
-      event_name: event === 'replay_progress' ? 'video_checkpoint' : event,
+      event_name: funnelEventName,
       event_value: String(currentSecond),
       page_path: '/mc2/replay/',
-      metadata: { route: '/mc2/replay/' },
+      metadata: eventMeta,
       dedupe_key: event === 'replay_progress'
         ? `recovery_replay_${access.job.id}_${Math.floor(currentSecond / 60)}`
         : `recovery_${event}_${access.job.id}`,
     }, { prefer: 'return=minimal' }).catch(() => {});
+    const metaEvents = mc2FunnelMetaEvents({
+      eventName: funnelEventName,
+      value: event === 'replay_progress' ? currentSecond / 60 : body.value,
+      meta: eventMeta,
+      registration: access.registration,
+    });
+    if (metaEvents.length > 0) {
+      try {
+        await sendMc2MetaEvents({
+          events: metaEvents,
+          registration: access.registration,
+          req,
+          pagePath: '/mc2/replay/',
+        });
+      } catch (error) {
+        console.error('MC2 Meta replay event failed:', error?.message || error);
+      }
+    }
     return json(200, {
       ok: true,
       ...(offerDeadline ? {

--- a/netlify/functions/register-mc2.js
+++ b/netlify/functions/register-mc2.js
@@ -4,6 +4,10 @@ import { validateMc2SessionSelection } from './lib/mc2-session.mjs';
 import { queueMc2Sms } from './lib/mc2-sms.mjs';
 import { queueMc2SessionEmails } from './lib/mc2-session-emails.mjs';
 import { upsertWebinaireSubscriber } from './lib/mailerlite-webinaire.mjs';
+import {
+  mc2RegistrationMetaEvents,
+  sendMc2MetaEvents,
+} from './lib/mc2-meta-events.mjs';
 
 function jsonResponse(status, payload) {
   return new Response(JSON.stringify(payload), {
@@ -29,7 +33,7 @@ function trim(value, max = 255) {
   return cleaned ? cleaned.slice(0, max) : null;
 }
 
-function registrationResponse(row, alreadyRegistered = false) {
+function registrationResponse(row, alreadyRegistered = false, metaEvents = []) {
   return {
     success: true,
     alreadyRegistered,
@@ -40,7 +44,20 @@ function registrationResponse(row, alreadyRegistered = false) {
     slotKind: row.slot_kind,
     visitorTimezone: row.visitor_timezone,
     redirectTo: `/mc2/confirmation?t=${encodeURIComponent(row.token)}`,
+    ...(metaEvents.length > 0 ? { metaEvents } : {}),
   };
+}
+
+async function deliverRegistrationMetaEvents(req, row, options) {
+  const events = mc2RegistrationMetaEvents(row, options);
+  if (events.length === 0) return [];
+  try {
+    await sendMc2MetaEvents({ events, registration: row, req });
+  } catch (error) {
+    // Meta ne doit jamais bloquer l'inscription MC2.
+    console.error('MC2 Meta registration event failed:', error?.message || error);
+  }
+  return events;
 }
 
 async function queueLiveReminder(row) {
@@ -143,6 +160,7 @@ export default async (req) => {
 
     if (Array.isArray(existing.data) && existing.data.length > 0) {
       const row = existing.data[0];
+      const completedBefore = Boolean(row.registration_completed_at);
       const patch = {
         prenom,
         ...sessionFields,
@@ -179,7 +197,11 @@ export default async (req) => {
       await syncMailerLite(completedRow);
       await queueLiveReminder(completedRow);
       if (isComplete) await queueSessionEmails(completedRow);
-      return jsonResponse(200, registrationResponse(completedRow, true));
+      const metaEvents = await deliverRegistrationMetaEvents(req, completedRow, {
+        created: false,
+        completedNow: isComplete && !completedBefore,
+      });
+      return jsonResponse(200, registrationResponse(completedRow, true, metaEvents));
     }
 
     const row = {
@@ -215,7 +237,11 @@ export default async (req) => {
     await queueLiveReminder(row);
     await syncMailerLite(row);
     if (isComplete) await queueSessionEmails(row);
-    return jsonResponse(200, registrationResponse(row));
+    const metaEvents = await deliverRegistrationMetaEvents(req, row, {
+      created: true,
+      completedNow: isComplete,
+    });
+    return jsonResponse(200, registrationResponse(row, false, metaEvents));
   } catch (error) {
     console.error('register-mc2 error:', error);
     return jsonResponse(500, {

--- a/netlify/functions/track-mc2-event.js
+++ b/netlify/functions/track-mc2-event.js
@@ -1,6 +1,10 @@
 import { supabaseGet, supabasePatch, supabasePost } from './lib/supabase-rest.mjs';
 import { ensureMc2OfferDeadline } from './lib/mc2-offer-deadline.mjs';
 import { excludeWebinarAttendee } from './lib/webinaire-exclusions.mjs';
+import {
+  mc2FunnelMetaEvents,
+  sendMc2MetaEvents,
+} from './lib/mc2-meta-events.mjs';
 
 const ALLOWED_EVENTS = new Set([
   'confirmation_viewed',
@@ -87,6 +91,7 @@ function sanitizeMeta(value) {
     if (text) output[key] = text;
   }
   if (input.percent != null) output.percent = positiveInt(input.percent, 100);
+  if (input.duration_seconds != null) output.duration_seconds = positiveInt(input.duration_seconds, 86400);
   if (input.active_seconds != null) output.active_seconds = positiveInt(input.active_seconds, 86400);
   if (typeof input.checkout_enabled === 'boolean') output.checkout_enabled = input.checkout_enabled;
   if (typeof input.stripe_ready === 'boolean') output.stripe_ready = input.stripe_ready;
@@ -210,6 +215,12 @@ export default async (req) => {
 
     const row = registration.data[0];
     const meta = sanitizeMeta(body?.meta);
+    const metaEvents = mc2FunnelMetaEvents({
+      eventName,
+      value: body?.value,
+      meta,
+      registration: row,
+    });
     let offerDeadline = null;
     if (eventName === 'cta_reached') {
       offerDeadline = await ensureMc2OfferDeadline({ token, registration: row, source: 'live' });
@@ -237,6 +248,19 @@ export default async (req) => {
     const inserted = await supabasePost('mc2_funnel_events', event, { prefer: 'return=minimal' });
     if (!inserted.ok && inserted.status !== 409) {
       console.error('track-mc2-event insert:', inserted.status, inserted.error);
+    }
+    if (metaEvents.length > 0) {
+      try {
+        await sendMc2MetaEvents({
+          events: metaEvents,
+          registration: row,
+          req,
+          pagePath: meta.page_path,
+        });
+      } catch (error) {
+        // Le tracking Meta ne doit jamais altérer le parcours MC2.
+        console.error('MC2 Meta funnel event failed:', error?.message || error);
+      }
     }
     return jsonResponse(200, {
       ok: true,

--- a/netlify/functions/track-mc2-optin.js
+++ b/netlify/functions/track-mc2-optin.js
@@ -10,7 +10,14 @@ const ALLOWED_EVENTS = new Set([
   'registration_submitted',
   'registration_completed',
 ]);
-const ALLOWED_PATHS = new Set(['/mc2/', '/meta/mc2/', '/tt/mc2/']);
+const ALLOWED_PATHS = new Set([
+  '/mc2/',
+  '/meta/mc2/',
+  '/tt/mc2/',
+  '/masterclass/',
+  '/meta/masterclass/',
+  '/tt/masterclass/',
+]);
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function json(status, payload) {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:pay-drafts": "node scripts/pay-draft-store-smoke.mjs",
     "test:pay-sql": "node scripts/pay-sql-guard.mjs",
     "test:mc2-pay-router": "node scripts/mc2-pay-router-smoke.mjs",
+    "test:mc2-meta-events": "node scripts/mc2-meta-events-smoke.mjs",
     "test:mc2-mailerlite-buyers": "node scripts/mc2-mailerlite-buyers-smoke.mjs",
     "test:mc2-checkout-ui": "node scripts/mc2-checkout-ui-smoke.mjs",
     "test:mc2-checkout-observability": "node scripts/mc2-checkout-observability-smoke.mjs",

--- a/scripts/mc2-meta-events-smoke.mjs
+++ b/scripts/mc2-meta-events-smoke.mjs
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import {
+  mc2FunnelMetaEvents,
+  mc2MetaRequestContext,
+  mc2RegistrationMetaEvents,
+  sendMc2MetaEvents,
+} from '../netlify/functions/lib/mc2-meta-events.mjs';
+
+const metaRegistration = {
+  token: '11111111-2222-4333-8444-555555555555',
+  email: 'lead@example.com',
+  telephone: '+33 6 12 34 56 78',
+  traffic_source: 'meta_ad',
+  meta_fbc: 'fb.1.123.click',
+  meta_fbp: 'fb.1.123.browser',
+  meta_event_id: 'browser-lead-id',
+  optin_variant: 'meta_v2_test',
+};
+
+assert.deepEqual(mc2RegistrationMetaEvents({ ...metaRegistration, traffic_source: null }, {
+  created: true,
+  completedNow: true,
+}), []);
+assert.deepEqual(
+  mc2RegistrationMetaEvents(metaRegistration, { created: true }).map((event) => event.eventName),
+  ['EmailCaptured'],
+);
+assert.deepEqual(
+  mc2RegistrationMetaEvents(metaRegistration, { completedNow: true }).map((event) => [event.eventName, event.eventId]),
+  [['Lead', 'browser-lead-id']],
+);
+
+assert.deepEqual(
+  mc2FunnelMetaEvents({ eventName: 'session_joined', registration: metaRegistration }).map((event) => event.eventName),
+  ['QualifiedLead'],
+);
+assert.deepEqual(mc2FunnelMetaEvents({
+  eventName: 'session_joined',
+  registration: { ...metaRegistration, attended_live: true },
+}), []);
+assert.deepEqual(mc2FunnelMetaEvents({
+  eventName: 'video_checkpoint',
+  value: 30,
+  meta: { percent: 31, duration_seconds: 5717 },
+  registration: { ...metaRegistration, watch_max_minutes: 15 },
+}).map((event) => event.eventName), ['QualifiedView25']);
+assert.deepEqual(mc2FunnelMetaEvents({
+  eventName: 'video_checkpoint',
+  value: 60,
+  meta: { percent: 63, duration_seconds: 5717 },
+  registration: { ...metaRegistration, watch_max_minutes: 30 },
+}).map((event) => event.eventName), ['QualifiedView50']);
+assert.deepEqual(mc2FunnelMetaEvents({
+  eventName: 'video_checkpoint',
+  value: 75,
+  meta: { percent: 79, duration_seconds: 5717 },
+  registration: { ...metaRegistration, watch_max_minutes: 60 },
+}).map((event) => event.eventName), ['QualifiedView75']);
+assert.deepEqual(
+  mc2FunnelMetaEvents({ eventName: 'cta_reached', registration: metaRegistration }).map((event) => event.eventName),
+  ['OfferViewed'],
+);
+assert.deepEqual(
+  mc2FunnelMetaEvents({ eventName: 'cta_clicked', registration: metaRegistration }).map((event) => event.eventName),
+  ['CTA_Clicked'],
+);
+assert.deepEqual(
+  mc2FunnelMetaEvents({ eventName: 'checkout_viewed', registration: metaRegistration }).map((event) => event.eventName),
+  ['InitiateCheckout'],
+);
+
+const req = new Request('https://sonnycourt.com/.netlify/functions/register-mc2', {
+  headers: {
+    referer: 'https://sonnycourt.com/meta/masterclass/',
+    'x-nf-client-connection-ip': '203.0.113.20',
+    'user-agent': 'MC2 smoke',
+  },
+});
+assert.deepEqual(mc2MetaRequestContext(req), {
+  ip: '203.0.113.20',
+  userAgent: 'MC2 smoke',
+  url: 'https://sonnycourt.com/meta/masterclass/',
+});
+
+const previousFetch = globalThis.fetch;
+const previousToken = process.env.META_ACCESS_TOKEN;
+const previousPixel = process.env.META_PIXEL_ID;
+const previousContext = process.env.CONTEXT;
+let capiRequest = null;
+process.env.META_ACCESS_TOKEN = 'test-access-token';
+process.env.META_PIXEL_ID = '3367958190030822';
+delete process.env.CONTEXT;
+globalThis.fetch = async (url, options) => {
+  capiRequest = { url: String(url), options };
+  return new Response(JSON.stringify({ events_received: 1 }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+
+await sendMc2MetaEvents({
+  events: mc2RegistrationMetaEvents(metaRegistration, { completedNow: true }),
+  registration: metaRegistration,
+  req,
+});
+assert.match(capiRequest.url, /\/3367958190030822\/events$/);
+const capiBody = JSON.parse(capiRequest.options.body);
+assert.equal(capiBody.data[0].event_name, 'Lead');
+assert.equal(capiBody.data[0].event_id, 'browser-lead-id');
+assert.equal(capiBody.data[0].event_source_url, 'https://sonnycourt.com/meta/masterclass/');
+assert.equal(Array.isArray(capiBody.data[0].user_data.external_id), true);
+assert.equal(capiBody.data[0].user_data.external_id[0].length, 64);
+assert.equal(capiRequest.options.body.includes('lead@example.com'), false);
+assert.equal(capiRequest.options.body.includes('+33 6 12 34 56 78'), false);
+
+process.env.CONTEXT = 'deploy-preview';
+capiRequest = null;
+await sendMc2MetaEvents({
+  events: mc2RegistrationMetaEvents(metaRegistration, { completedNow: true }),
+  registration: metaRegistration,
+  req,
+});
+assert.equal(capiRequest, null);
+
+globalThis.fetch = previousFetch;
+if (previousToken === undefined) delete process.env.META_ACCESS_TOKEN;
+else process.env.META_ACCESS_TOKEN = previousToken;
+if (previousPixel === undefined) delete process.env.META_PIXEL_ID;
+else process.env.META_PIXEL_ID = previousPixel;
+if (previousContext === undefined) delete process.env.CONTEXT;
+else process.env.CONTEXT = previousContext;
+
+const adapter = await readFile(new URL('../src/components/Mc2PaidOptinAdapter.astro', import.meta.url), 'utf8');
+const register = await readFile(new URL('../netlify/functions/register-mc2.js', import.meta.url), 'utf8');
+const tracker = await readFile(new URL('../netlify/functions/track-mc2-event.js', import.meta.url), 'utf8');
+const router = await readFile(new URL('../netlify/functions/lib/mc2-pay-router.mjs', import.meta.url), 'utf8');
+const optinTracker = await readFile(new URL('../netlify/functions/track-mc2-optin.js', import.meta.url), 'utf8');
+const organicOptin = await readFile(new URL('../src/pages/mc2/index.astro', import.meta.url), 'utf8');
+
+assert.match(adapter, /fbq\('track', 'Lead',[\s\S]*eventID: event\.eventId/);
+assert.match(adapter, /fbq\('trackCustom', event\.eventName,[\s\S]*eventID: event\.eventId/);
+assert.match(register, /completedNow: isComplete && !completedBefore/);
+assert.match(tracker, /mc2FunnelMetaEvents/);
+assert.match(router, /eventName: 'Purchase'/);
+assert.match(router, /Number\(session\.amount_total \|\| MC2_ENTRY_PAYMENT_CENTS\) \/ 100/);
+assert.match(optinTracker, /'\/meta\/masterclass\/'/);
+assert.match(organicOptin, /fetch\('\/\.netlify\/functions\/track-mc2-optin'/);
+
+console.log('mc2 meta events smoke: ok');

--- a/src/components/Mc2PaidOptinAdapter.astro
+++ b/src/components/Mc2PaidOptinAdapter.astro
@@ -116,6 +116,21 @@ const {
             return new Promise(function () {});
         }
 
+        function fireMetaBrowserEvents(data) {
+            if (source !== 'meta_ad' || !window.fbq || !Array.isArray(data && data.metaEvents)) return;
+            data.metaEvents.forEach(function (event) {
+                if (!event || !event.eventName || !event.eventId) return;
+                var params = {
+                    content_name: event.contentName || 'Masterclass ES2'
+                };
+                if (event.eventName === 'Lead') {
+                    window.fbq('track', 'Lead', params, { eventID: event.eventId });
+                } else {
+                    window.fbq('trackCustom', event.eventName, params, { eventID: event.eventId });
+                }
+            });
+        }
+
         function discloseSmsReminders() {
             document.querySelectorAll('.phone-privacy-note span').forEach(function (node) {
                 node.textContent = 'Ton numéro reste confidentiel. En continuant, tu acceptes les 2 rappels SMS liés à ta session et à son offre.';
@@ -163,6 +178,7 @@ const {
 
             if (kind === 'registration-write' && data && data.success && data.token) {
                 saveMc2Token(data.token);
+                try { fireMetaBrowserEvents(data); } catch (error) {}
                 var payload = {};
                 try { payload = JSON.parse((nextInit && nextInit.body) || '{}'); } catch (error) {}
                 if (payload.telephone && payload.pays) {

--- a/src/pages/mc2/index.astro
+++ b/src/pages/mc2/index.astro
@@ -2317,7 +2317,7 @@ import Mc2SafetyGuard from '../../components/Mc2SafetyGuard.astro';
                     selected_country: state.country || null,
                     session_date: session ? session.toISOString() : null,
                 };
-                fetch('/.netlify/functions/track-masterclass-optin', {
+                fetch('/.netlify/functions/track-mc2-optin', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(payload),

--- a/src/pages/mc2/replay.astro
+++ b/src/pages/mc2/replay.astro
@@ -1157,13 +1157,19 @@ import GAConsentMode from '../../components/GAConsentMode.astro';
         });
       } catch {}
     }
-    function trackWebinaireEvent(token, eventName, value) {
+    function trackWebinaireEvent(token, eventName, value, progressMeta) {
       if (!recoveryAccessCode || !eventName) return Promise.resolve(null);
       const mappedEvent = eventName === 'video_checkpoint' ? 'replay_progress' : eventName;
       if (!['replay_started', 'replay_progress', 'cta_reached'].includes(mappedEvent)) return Promise.resolve(null);
       const payload = { access: recoveryAccessCode, event: mappedEvent };
       if (mappedEvent === 'replay_progress') payload.currentSecond = Math.max(0, Math.floor(Number(value) * 60 || 0));
       if (value !== undefined && value !== null) payload.value = String(value);
+      if (progressMeta && Number.isFinite(Number(progressMeta.percent))) {
+        payload.percent = Math.max(0, Math.min(100, Math.round(Number(progressMeta.percent))));
+      }
+      if (progressMeta && Number.isFinite(Number(progressMeta.durationSeconds))) {
+        payload.duration_seconds = Math.max(1, Math.floor(Number(progressMeta.durationSeconds)));
+      }
       console.log('[ES2 TRACKING]', eventName, payload);
       return fetch('/.netlify/functions/mc2-replay-track', {
         method: 'POST',
@@ -1918,7 +1924,11 @@ import GAConsentMode from '../../components/GAConsentMode.astro';
         VIDEO_TRACKING_CHECKPOINTS_MIN.forEach((checkpointMin) => {
           if (watchedMinutes >= checkpointMin && !emittedCheckpointMinutes.has(checkpointMin)) {
             emittedCheckpointMinutes.add(checkpointMin);
-            trackWebinaireEvent(token, 'video_checkpoint', checkpointMin);
+            const durationSeconds = Number.isFinite(video.duration) && video.duration > 0 ? video.duration : null;
+            trackWebinaireEvent(token, 'video_checkpoint', checkpointMin, {
+              percent: durationSeconds ? (checkpointMin * 60 * 100) / durationSeconds : null,
+              durationSeconds,
+            });
           }
         });
       });

--- a/src/pages/mc2/session.astro
+++ b/src/pages/mc2/session.astro
@@ -1550,7 +1550,14 @@ import Mc2AccessGate from '../../components/Mc2AccessGate.astro';
         function trackWebinaireEvent(token, eventName, value) {
             if (!token || !eventName) return Promise.resolve(null);
             const payload = { token, event: eventName, meta: { page_path: '/mc2/session/' } };
-            if (value !== undefined && value !== null) payload.value = String(value);
+            if (value !== undefined && value !== null) {
+                payload.value = String(value);
+                if (eventName === 'video_checkpoint') {
+                    const durationSeconds = getVideoDurationSeconds();
+                    payload.meta.duration_seconds = Math.max(1, Math.floor(durationSeconds));
+                    payload.meta.percent = Math.min(100, Math.round((Number(value) * 60 * 100) / durationSeconds));
+                }
+            }
             console.log('[ES2 TRACKING]', eventName, payload);
             return fetch('/.netlify/functions/track-mc2-event', {
                 method: 'POST',


### PR DESCRIPTION
## Correctif\n- rétablit EmailCaptured et Lead avec déduplication Pixel/CAPI\n- remonte QualifiedLead, vues 25/50/75, offre, CTA et checkout\n- remonte Purchase uniquement après confirmation Stripe\n- corrige le tracking opt-in MC2 et les anciennes routes /meta/masterclass\n- désactive CAPI hors production\n\n## Vérifications\n- suites MC2, checkout, replay et paiement : OK\n- build Astro : OK\n- preview Netlify + sas anti-régression : OK\n- contrôle navigateur /meta/masterclass : OK